### PR TITLE
[BUG] Updated eTrading pages to flow correctly

### DIFF
--- a/IonicApps/skippyQ/src/app/buy-trade-stock-completed/buy-trade-stock-completed.page.html
+++ b/IonicApps/skippyQ/src/app/buy-trade-stock-completed/buy-trade-stock-completed.page.html
@@ -1,13 +1,13 @@
 <ion-header class="ion-padding">
   <ion-toolbar>
-    <ion-buttons slot="start" [routerLink]="['/buy-trade']">
-      <ion-icon color="medium" name="chevron-back-outline"></ion-icon>
-    </ion-buttons>
     <ion-row>
     <ion-col>
     <ion-title>Buy Order</ion-title>
      Order Review
     </ion-col>
+      <ion-button [routerLink]="['/trading-home']">
+        <ion-icon name="close-outline"></ion-icon>
+      </ion-button>
     </ion-row>
     <br>
     <ion-progress-bar value="0.60"></ion-progress-bar>

--- a/IonicApps/skippyQ/src/app/buy-trade-stock-review/buy-trade-stock-review.page.html
+++ b/IonicApps/skippyQ/src/app/buy-trade-stock-review/buy-trade-stock-review.page.html
@@ -1,6 +1,6 @@
 <ion-header class="ion-padding">
   <ion-toolbar>
-    <ion-buttons slot="start" [routerLink]="['/buy-trade']">
+    <ion-buttons slot="start" [routerLink]="['/buy-trade-stock-success']">
       <ion-icon color="medium" name="chevron-back-outline"></ion-icon>
     </ion-buttons>
     <ion-row>

--- a/IonicApps/skippyQ/src/app/buy-trade-stock-success/buy-trade-stock-success.page.html
+++ b/IonicApps/skippyQ/src/app/buy-trade-stock-success/buy-trade-stock-success.page.html
@@ -1,6 +1,6 @@
 <ion-header class="ion-padding">
   <ion-toolbar>
-    <ion-buttons slot="start" [routerLink]="['/buy-trade']">
+    <ion-buttons slot="start" [routerLink]="['/buy-trade-stock']">
       <ion-icon color="medium" name="chevron-back-outline"></ion-icon>
     </ion-buttons>
     <ion-row>

--- a/IonicApps/skippyQ/src/app/buy-trade-stock/buy-trade-stock.page.html
+++ b/IonicApps/skippyQ/src/app/buy-trade-stock/buy-trade-stock.page.html
@@ -1,6 +1,6 @@
 <ion-header class="ion-padding">
   <ion-toolbar>
-    <ion-buttons slot="start" [routerLink]="['/investment-ideas']">
+    <ion-buttons slot="start" [routerLink]="['/buy-trade']">
       <ion-icon color="medium" name="chevron-back-outline"></ion-icon>
     </ion-buttons>
     <ion-row>

--- a/IonicApps/skippyQ/src/app/buy-trade/buy-trade.page.html
+++ b/IonicApps/skippyQ/src/app/buy-trade/buy-trade.page.html
@@ -1,6 +1,6 @@
 <ion-header class="ion-padding">
   <ion-toolbar>
-    <ion-buttons slot="start" [routerLink]="['/investment-ideas']">
+    <ion-buttons slot="start" [routerLink]="['/trading-home']">
       <ion-icon color="medium" name="chevron-back-outline"></ion-icon>
     </ion-buttons>
     <ion-row>

--- a/IonicApps/skippyQ/src/app/sell-trade-stock-completed/sell-trade-stock-completed.page.html
+++ b/IonicApps/skippyQ/src/app/sell-trade-stock-completed/sell-trade-stock-completed.page.html
@@ -1,13 +1,13 @@
 <ion-header class="ion-padding">
   <ion-toolbar>
-    <ion-buttons slot="start" [routerLink]="['/buy-trade-stock']">
-      <ion-icon color="medium" name="chevron-back-outline"></ion-icon>
-    </ion-buttons>
     <ion-row>
     <ion-col>
     <ion-title>Sell Order</ion-title>
      Order Review
     </ion-col>
+    <ion-button [routerLink]="['/trading-home']">
+      <ion-icon name="close-outline"></ion-icon>
+    </ion-button>
     </ion-row>
     <br>
     <ion-progress-bar value="0.60"></ion-progress-bar>

--- a/IonicApps/skippyQ/src/app/sell-trade-stock/sell-trade-stock.page.html
+++ b/IonicApps/skippyQ/src/app/sell-trade-stock/sell-trade-stock.page.html
@@ -1,6 +1,6 @@
 <ion-header class="ion-padding">
   <ion-toolbar>
-    <ion-buttons slot="start" [routerLink]="['/investment-ideas']">
+    <ion-buttons slot="start" [routerLink]="['/sell-trade']">
       <ion-icon color="medium" name="chevron-back-outline"></ion-icon>
     </ion-buttons>
     <ion-row>

--- a/IonicApps/skippyQ/src/app/sell-trade/sell-trade.page.html
+++ b/IonicApps/skippyQ/src/app/sell-trade/sell-trade.page.html
@@ -1,6 +1,6 @@
 <ion-header class="ion-padding">
   <ion-toolbar>
-    <ion-buttons slot="start" [routerLink]="['/investment-ideas']">
+    <ion-buttons slot="start" [routerLink]="['/trading-home']">
       <ion-icon color="medium" name="chevron-back-outline"></ion-icon>
     </ion-buttons>
     <ion-row>


### PR DESCRIPTION
eTrading pages needed to be updated to ensure that screens flow correctly.
Replaced [<] icons with [x] icons on trade 'completed' pages to follow the screens provided by UBS