### PR TITLE
[Bug] Fixed issue on Trading Detail initial page load

### DIFF
--- a/IonicApps/skippyQ/src/app/trade-details/trade-details.page.ts
+++ b/IonicApps/skippyQ/src/app/trade-details/trade-details.page.ts
@@ -125,7 +125,7 @@ export class TradeDetailsPage implements OnInit{
 
   ngOnInit() {
 
-  this.selectedDetail = "Order Data"
+  this.selectedDetail = "Order"
   this.initTime = window.performance.now()
   localStorage.setItem("pageLoadTime", JSON.stringify((this.initTime-this.startTime)/1000))
 


### PR DESCRIPTION
Page loads without the initial selection of 'Order Data' tab.